### PR TITLE
fix package SlimList is empty by store content of slim.json in slim.js

### DIFF
--- a/demo/src/Demo.js
+++ b/demo/src/Demo.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import Ribbon, { RibbonDataProvider } from '../../src/';
+import '../../src/index.css';
 import history from './history';
 import { addUrlProps, UrlQueryParamTypes } from 'react-url-query';
 

--- a/src/Ribbon.js
+++ b/src/Ribbon.js
@@ -2,8 +2,6 @@
 import React, { Component, PropTypes } from 'react'
 //import PropTypes from 'prop-types';
 
-import './index.css';
-
 import Strip from './components/Strip';
 
 export default class Ribbon extends React.Component {

--- a/src/RibbonDataProvider.js
+++ b/src/RibbonDataProvider.js
@@ -5,7 +5,8 @@ import React, { Component, PropTypes } from 'react'
 
 import axios from 'axios';
 
-import SlimList from './slim.json';
+import SLIM_LIST from './slim';
+
 
 var BIOLINK =
 'https://api.monarchinitiative.org/api/bioentityset/slimmer/function?slim=GO:0003824&slim=GO:0004872&slim=GO:0005102&slim=GO:0005215&slim=GO:0005198&slim=GO:0008092&slim=GO:0003677&slim=GO:0003723&slim=GO:0001071&slim=GO:0036094&slim=GO:0046872&slim=GO:0030246&slim=GO:0008283&slim=GO:0071840&slim=GO:0051179&slim=GO:0032502&slim=GO:0000003&slim=GO:0002376&slim=GO:0050877&slim=GO:0050896&slim=GO:0023052&slim=GO:0010467&slim=GO:0019538&slim=GO:0006259&slim=GO:0044281&slim=GO:0050789&slim=GO:0005576&slim=GO:0005829&slim=GO:0005856&slim=GO:0005739&slim=GO:0005634&slim=GO:0005694&slim=GO:0016020&slim=GO:0071944&slim=GO:0030054&slim=GO:0042995&slim=GO:0032991&subject=';
@@ -66,7 +67,7 @@ export default class RibbonDataProvider extends React.Component {
 
   render() {
     const {title, responseData, dataReceived, dataError } = this.state;
-    const data = SlimList.map((slimStub) => {
+    const data = SLIM_LIST.map((slimStub) => {
       const matchingSlim = responseData.find((responseSlimItem) => (
         responseSlimItem.slim === slimStub.goid
       ));

--- a/src/slim.js
+++ b/src/slim.js
@@ -1,4 +1,4 @@
-[
+export default [
   {
     "goid": "GO:0003824",
     "golabel": "catalysis"
@@ -147,4 +147,4 @@
     "goid": "GO:0032991",
     "golabel": "macromolecular complex"
   }
-]
+];


### PR DESCRIPTION
Hi @selewis All the `import` of non-javascript resource probably has to go (from the src/). The reason is that json and css import needs to be converted to JS (using loaders) for things to work. This step only happens in webpack (for example running the development server), but not `nwb build-react-component --copy-files`, which uses Babel alone. This puts extra burden on users of the library, as they would need to setup appropriate loaders for things to work for them.

So a quick fix is to turn the slim.js into an actual javascript file with appropriate export.

Additionally, I moved the css import out of the component into the demo. Otherwise, [it breaks mocha test](http://stackoverflow.com/questions/32236443/mocha-testing-failed-due-to-css-in-webpack).