### PR TITLE
Pass props and declare propTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "axios": "0.16.1",
     "bluebird": "^3.5.0",
+    "flux": "3.1.3",
     "halogen": "^0.2.0",
     "prop-types": "^15.5.10",
     "react-flip-move": "^2.9.14",

--- a/src/Ribbon.js
+++ b/src/Ribbon.js
@@ -141,7 +141,10 @@ export default class Ribbon extends React.Component {
         <div >
           <Strip />
           <div className='caption' >{this.state.title}</div>
-          <AssociationsView title={this.state.title} />
+          <AssociationsView
+            title={this.state.title}
+            slimlist={RibbonStore.getSlimList()}
+          />
         </div>
       );
     }

--- a/src/Ribbon.js
+++ b/src/Ribbon.js
@@ -119,7 +119,7 @@ export default class Ribbon extends React.Component {
     });
   }
 
-  handleTermSelect = (termId) => {
+  handleSlimSelect = (termId) => {
     this.setState({
       currentTermId: termId
     });
@@ -146,7 +146,7 @@ export default class Ribbon extends React.Component {
       return(
         <div >
           <Strip
-            onTermSelect={(termId) => this.handleTermSelect(termId)}
+            onSlimSelect={(termId) => this.handleSlimSelect(termId)}
             slimlist={RibbonStore.getSlimList()}
           />
           <div className='caption' >{this.state.title}</div>

--- a/src/Ribbon.js
+++ b/src/Ribbon.js
@@ -119,6 +119,12 @@ export default class Ribbon extends React.Component {
     });
   }
 
+  handleTermSelect = (termId) => {
+    this.setState({
+      currentTermId: termId
+    });
+  }
+
   render() {
     const size = 8;
     const margin = 2;
@@ -139,10 +145,14 @@ export default class Ribbon extends React.Component {
     if (this.state.dataError === null) {
       return(
         <div >
-          <Strip />
+          <Strip
+            onTermSelect={(termId) => this.handleTermSelect(termId)}
+            slimlist={RibbonStore.getSlimList()}
+          />
           <div className='caption' >{this.state.title}</div>
           <AssociationsView
             title={this.state.title}
+            currentTermId={this.state.currentTermId}
             slimlist={RibbonStore.getSlimList()}
           />
         </div>

--- a/src/data/RibbonStore.js
+++ b/src/data/RibbonStore.js
@@ -25,35 +25,35 @@ class RibbonStore extends ReduceStore {
     return _blocks;
   }
 
-  /*
-  Apparently this is what the dispatcher calls to deliver the data to the store
-  */
-  reduce(before, action) {
-    if (action.type === ActionType.TOGGLE) {
-      var slimitem = _blocks.get(action.value.goid);
-      _blocks.forEach(function (goclass, goid) {
-        // only one at a time can be visible
-        if (goid !== action.value.goid && goclass.visible) {
-          goclass.visible = false;
-        }
-      });
-      slimitem.visible = !slimitem.visible;
-      var after = new Map(_blocks);
-      return after;
-    }
-    else {
-      return before;
-    }
-  }
-
-  isVisible(goid) {
-    var slimitem = _blocks.get(goid);
-    var visible = slimitem.visible;
-    if (typeof(visible) === 'undefined' || visible === null) {
-      visible = false
-    }
-    return visible;
-  }
+  // /*
+  // Apparently this is what the dispatcher calls to deliver the data to the store
+  // */
+  // reduce(before, action) {
+  //   if (action.type === ActionType.TOGGLE) {
+  //     var slimitem = _blocks.get(action.value.goid);
+  //     _blocks.forEach(function (goclass, goid) {
+  //       // only one at a time can be visible
+  //       if (goid !== action.value.goid && goclass.visible) {
+  //         goclass.visible = false;
+  //       }
+  //     });
+  //     slimitem.visible = !slimitem.visible;
+  //     var after = new Map(_blocks);
+  //     return after;
+  //   }
+  //   else {
+  //     return before;
+  //   }
+  // }
+  //
+  // isVisible(goid) {
+  //   var slimitem = _blocks.get(goid);
+  //   var visible = slimitem.visible;
+  //   if (typeof(visible) === 'undefined' || visible === null) {
+  //     visible = false
+  //   }
+  //   return visible;
+  // }
 
   getSlimList() {
     var list = _blocks.values();

--- a/src/view/AssociationsView.js
+++ b/src/view/AssociationsView.js
@@ -29,6 +29,8 @@ class AssociationsView extends Component {
       return <AssociationList
         goid={slimitem.goid}
         key={slimitem.goid}
+        slimitem={slimitem}
+        visible={slimitem.visible}
       />;
     });
     return (
@@ -40,29 +42,13 @@ class AssociationsView extends Component {
 };
 
 class AssociationList extends Component {
-  constructor(props) {
-    super(props);
-    const {goid} = this.props;
-    var visible = RibbonStore.isVisible(goid);
-    this.state = ({
-      visible: visible
-    });
-  }
 
-  componentDidMount() {
-    RibbonStore.addListener(this.onToggle.bind(this), ActionType.TOGGLE );
-  }
-
-  onToggle() {
-    var visible = RibbonStore.isVisible(this.props.goid);
-    this.setState({
-      visible: visible}
-    );
-  }
-
-  componentWillUnmount() {
-    //RibbonStore.removeListener(this.onToggle.bind(this) );
-  }
+  static propTypes = {
+    slimitem: PropTypes.shape({
+      uniqueAssocs: PropTypes.array
+    }),
+    visible: PropTypes.bool
+  };
 
   renderAssociations(slimitem) {
     return slimitem.uniqueAssocs.map((assoc, index) => {
@@ -77,9 +63,8 @@ class AssociationList extends Component {
     return `cubic-bezier(${ easingValues.join(',') })`;
   }
   render() {
-    const {goid} = this.props;
-    var slimitem = RibbonStore.getSlimItem(goid);
-    var rows = ( this.state.visible &&
+    const {goid, slimitem} = this.props;
+    var rows = ( this.props.visible &&
       <div className='assoc-list'>
         <div>
         <FlipMove
@@ -101,6 +86,23 @@ class AssociationList extends Component {
 
 class Association extends Component {
 
+  static propTypes = {
+    assoc: PropTypes.shape({
+      subject: PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
+        taxon: PropTypes.shape({
+          id: PropTypes.string.isRequired
+        }).isRequired,
+      }),
+      object: PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
+      }),
+      color: PropTypes.string
+    })
+  };
+
   render() {
     const { assoc } = this.props;
     const assocStyle = {
@@ -114,6 +116,7 @@ class Association extends Component {
     var genelink = `http://dev.alliancegenome.org:4001/gene/${assoc.subject.id}`;
     var golink = `http://amigo.geneontology.org/amigo/term/${assoc.object.id}`;
     console.log(golink);
+        console.log(assoc);
     return (
       <li style={assocStyle}>
         <img className='assoc-img' src={img} />

--- a/src/view/AssociationsView.js
+++ b/src/view/AssociationsView.js
@@ -5,15 +5,10 @@ import AGR_taxons from '../data/taxa';
 
 class AssociationsView extends Component {
   static propTypes = {
-    title: PropTypes.string.isRequired,
     currentTermId: PropTypes.string,
     slimlist: PropTypes.arrayOf(
       PropTypes.shape({
-        color: PropTypes.string,
-        goid: PropTypes.string,
-        golabel: PropTypes.string,
-        uniqueAssocs: PropTypes.array,
-        visible: PropTypes.bool
+        color: PropTypes.string
       })
     )
   };

--- a/src/view/AssociationsView.js
+++ b/src/view/AssociationsView.js
@@ -1,8 +1,6 @@
 import React, { Component, PropTypes }  from 'react';
 import FlipMove from 'react-flip-move';
 
-import RibbonStore from '../data/RibbonStore';
-import ActionType from '../event/ActionType';
 import AGR_taxons from '../data/taxa';
 
 class AssociationsView extends Component {

--- a/src/view/AssociationsView.js
+++ b/src/view/AssociationsView.js
@@ -8,6 +8,7 @@ import AGR_taxons from '../data/taxa';
 class AssociationsView extends Component {
   static propTypes = {
     title: PropTypes.string.isRequired,
+    currentTermId: PropTypes.string,
     slimlist: PropTypes.arrayOf(
       PropTypes.shape({
         color: PropTypes.string,
@@ -19,23 +20,22 @@ class AssociationsView extends Component {
     )
   };
 
-  constructor(props) {
-    super(props);
-  }
-
   render() {
     const {slimlist} = this.props;
-    const infoArray = slimlist.map((slimitem, index) => {
-      return <AssociationList
-        goid={slimitem.goid}
-        key={slimitem.goid}
-        slimitem={slimitem}
-        visible={slimitem.visible}
-      />;
-    });
     return (
       <div className='assoc-view'>
-        <div > {infoArray} </div>
+      {
+        slimlist.filter((slimitem) => {
+          return slimitem.goid === this.props.currentTermId;
+        }).map((slimitem) => {
+          return (
+            <AssociationList
+              key={slimitem.goid}
+              slimitem={slimitem}
+            />
+          )
+        })
+      }
       </div>
     );
   }
@@ -46,8 +46,7 @@ class AssociationList extends Component {
   static propTypes = {
     slimitem: PropTypes.shape({
       uniqueAssocs: PropTypes.array
-    }),
-    visible: PropTypes.bool
+    })
   };
 
   renderAssociations(slimitem) {
@@ -64,7 +63,7 @@ class AssociationList extends Component {
   }
   render() {
     const {goid, slimitem} = this.props;
-    var rows = ( this.props.visible &&
+    return (
       <div className='assoc-list'>
         <div>
         <FlipMove
@@ -79,8 +78,7 @@ class AssociationList extends Component {
         </FlipMove>
         </div>
       </div>
-    )
-    return rows;
+    );
   }
 }
 
@@ -116,7 +114,7 @@ class Association extends Component {
     var genelink = `http://dev.alliancegenome.org:4001/gene/${assoc.subject.id}`;
     var golink = `http://amigo.geneontology.org/amigo/term/${assoc.object.id}`;
     console.log(golink);
-        console.log(assoc);
+
     return (
       <li style={assocStyle}>
         <img className='assoc-img' src={img} />

--- a/src/view/AssociationsView.js
+++ b/src/view/AssociationsView.js
@@ -8,6 +8,15 @@ import AGR_taxons from '../data/taxa';
 class AssociationsView extends Component {
   static propTypes = {
     title: PropTypes.string.isRequired,
+    slimlist: PropTypes.arrayOf(
+      PropTypes.shape({
+        color: PropTypes.string,
+        goid: PropTypes.string,
+        golabel: PropTypes.string,
+        uniqueAssocs: PropTypes.array,
+        visible: PropTypes.bool
+      })
+    )
   };
 
   constructor(props) {
@@ -15,8 +24,8 @@ class AssociationsView extends Component {
   }
 
   render() {
-    var slimlist = RibbonStore.getSlimList();
-    const InfoArray = slimlist.map((slimitem, index) => {
+    const {slimlist} = this.props;
+    const infoArray = slimlist.map((slimitem, index) => {
       return <AssociationList
         goid={slimitem.goid}
         key={slimitem.goid}
@@ -24,7 +33,7 @@ class AssociationsView extends Component {
     });
     return (
       <div className='assoc-view'>
-        <div > {InfoArray} </div>
+        <div > {infoArray} </div>
       </div>
     );
   }

--- a/src/view/Block.js
+++ b/src/view/Block.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import RibbonStore from '../data/RibbonStore';
-import BlockDispatcher from '../event/BlockDispatcher';
 import ActionType from '../event/ActionType';
 
 class Block extends React.Component {

--- a/src/view/Block.js
+++ b/src/view/Block.js
@@ -33,8 +33,8 @@ class Block extends React.Component {
   }
 
   handleOnClick = (evt) => {
-    const {onTermSelect, goid} = this.props;
-    onTermSelect(goid);
+    const {onSlimSelect, goid} = this.props;
+    onSlimSelect(goid);
   }
 }
 
@@ -43,7 +43,7 @@ Block.propTypes = {
   golabel: PropTypes.string,
   color: PropTypes.string,
   uniqueAssocs: PropTypes.array.isRequired,
-  onTermSelect: PropTypes.func.isRequired
+  onSlimSelect: PropTypes.func.isRequired
 };
 
 export default Block;

--- a/src/view/Block.js
+++ b/src/view/Block.js
@@ -8,8 +8,7 @@ import ActionType from '../event/ActionType';
 class Block extends React.Component {
 
   render() {
-    const {goid} = this.props;
-    var slimitem = RibbonStore.getSlimItem(goid);
+    const slimitem = this.props;
     if (slimitem.separator === undefined) {
       const tileHoverString = (slimitem.uniqueAssocs.length > 0) ?
         slimitem.uniqueAssocs.length + ' associations ' : //uniqueHits.join('\n') :
@@ -43,6 +42,9 @@ class Block extends React.Component {
 
 Block.propTypes = {
   goid: PropTypes.string.isRequired,
+  golabel: PropTypes.string,
+  color: PropTypes.string,
+  uniqueAssocs: PropTypes.array.isRequired,
   onTermSelect: PropTypes.func.isRequired
 };
 

--- a/src/view/Block.js
+++ b/src/view/Block.js
@@ -36,21 +36,14 @@ class Block extends React.Component {
   }
 
   handleOnClick = (evt) => {
-    var slimitem = RibbonStore.getSlimItem(this.props.goid);
-    if (slimitem.uniqueAssocs.length > 0) {
-      BlockDispatcher.dispatch({
-        type: ActionType.TOGGLE,
-        value: {
-          goid: slimitem.goid,
-          visible: !(RibbonStore.isVisible(slimitem.goid))
-        }
-      });
-    }
+    const {onTermSelect, goid} = this.props;
+    onTermSelect(goid);
   }
 }
 
 Block.propTypes = {
-  goid: PropTypes.string.isRequired
+  goid: PropTypes.string.isRequired,
+  onTermSelect: PropTypes.func.isRequired
 };
 
 export default Block;

--- a/src/view/Strip.js
+++ b/src/view/Strip.js
@@ -9,9 +9,8 @@ export default class Strip extends React.Component {
   render() {
     const blocks = this.props.slimlist.map((slimitem, index) => {
       return <Block
-        goid={slimitem.goid}
+        {...slimitem}
         key={slimitem.goid}
-        slimlist={this.props.slimlist}
         onTermSelect={this.props.onTermSelect}
       />;
     });

--- a/src/view/Strip.js
+++ b/src/view/Strip.js
@@ -7,17 +7,23 @@ import RibbonStore from '../data/RibbonStore';
 export default class Strip extends React.Component {
 
   render() {
-    var slimlist = RibbonStore.getSlimList();
-    const StripOfBlocks = slimlist.map((slimitem, index) => {
+    const blocks = this.props.slimlist.map((slimitem, index) => {
       return <Block
         goid={slimitem.goid}
         key={slimitem.goid}
+        slimlist={this.props.slimlist}
+        onTermSelect={this.props.onTermSelect}
       />;
     });
     return(
       <div className='strip'>
-        <div>{StripOfBlocks}</div>
+        <div>{blocks}</div>
       </div>
     );
   }
+}
+
+Strip.propTypes = {
+  slimlist: PropTypes.array,
+  onTermSelect: PropTypes.func.isRequired
 }

--- a/src/view/Strip.js
+++ b/src/view/Strip.js
@@ -10,7 +10,7 @@ export default class Strip extends React.Component {
       return <Block
         {...slimitem}
         key={slimitem.goid}
-        onTermSelect={this.props.onTermSelect}
+        onSlimSelect={this.props.onSlimSelect}
       />;
     });
     return(
@@ -23,5 +23,5 @@ export default class Strip extends React.Component {
 
 Strip.propTypes = {
   slimlist: PropTypes.array,
-  onTermSelect: PropTypes.func.isRequired
+  onSlimSelect: PropTypes.func.isRequired
 }

--- a/src/view/Strip.js
+++ b/src/view/Strip.js
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types';
 
 import Block from './Block';
-import RibbonStore from '../data/RibbonStore';
 
 export default class Strip extends React.Component {
 


### PR DESCRIPTION
Hi @selewis ,

A little bit of refactoring to make the code easier to understand. Simple things first: this PR is about passing props from parent component to child component. 

Handing over global store to components indiscriminately is an anti-pattern. Not only the components are strongly coupled to the data formats for the global store, requiring parallel changes if structure of the store changes. Handing out global store means giving up cohesion in the application logic (any component can read from and dispatch action to store), so to understand the application logic, one needs to look at every component. 

Components are much easier to reason with and reuse, if props is the only thing they work with. https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0 With simple app like the Ribbon, really only the Ribbon component needs to be aware of the global state. 

Change summary:
- pass slimlist from Ribbon to Strip and AssociationsView
- pass onSlimSelect (event handler) from Ribbon to Block through Strip
- declare propTypes for AssociationsView, AssociationsList, Association, Block and Strip
- remove RibbonStore from all components except Ribbon 

