### PR TITLE
fixed wording and capitalization

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -134,7 +134,7 @@
   background-color: rgb(6, 100, 100);
   border: 1px solid white;
   border-radius: 5px;
-  box-shadow: -2px 2px 9px black;  
+  box-shadow: -2px 2px 9px black;
   margin-top: .2rem;
   padding: 5px 15px;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -350,6 +350,17 @@
   text-decoration: underline;
 }
 
+.closeable{
+  color: lightgray;
+  transform: scale(1.2);
+  transition: all 0.2s ease
+}
+
+.closeable:hover{
+  font-weight: bold;
+  transform: scale(1.4)
+}
+
 .bright {
   color: #FF1998;
   transform: scale(1.2);

--- a/src/view/FilterDropdown.js
+++ b/src/view/FilterDropdown.js
@@ -3,6 +3,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import FaFilter from 'react-icons/lib/fa/filter'
+import FaClose from 'react-icons/lib/fa/close'
 import FilterItem from './FilterItem';
 
 class FilterDropdown extends Component {
@@ -52,7 +53,7 @@ class FilterDropdown extends Component {
       null;
 
     const arrow = this.state.isOpen ?
-      (<FaFilter className='bright link' onClick={() => { this.handleMouseDown(); }} />) :
+      (<FaClose className='closeable link' onClick={() => { this.handleMouseDown(); }} />) :
       (<FaFilter className='bright link' onClick={() => { this.handleMouseDown(); }} />);
 
     return (

--- a/src/view/GeneAbout.js
+++ b/src/view/GeneAbout.js
@@ -46,7 +46,7 @@ export default class GeneAbout extends React.Component {
 
     speciesName = speciesName ? speciesName : subject;
 
-    let active_term = currentblock ? ' annotations to ' + currentblock.class_label : null;
+      let active_term = currentblock ? ' ' + currentblock.class_label : null;
 
     let isValid = Object.values(prefixToSpecies).indexOf(speciesName) >= 0;
     if (isValid) {
@@ -69,7 +69,7 @@ export default class GeneAbout extends React.Component {
                   target='_blank'
                 >
                   {this.getLabel(title)}
-                  {active_term}
+                  {active_term.toLowerCase()}
                   <FaExternalLink size={18} style={{paddingLeft: 10, textDecoration: 'none'}} />
                 </a>
               </span>


### PR DESCRIPTION
I decided to fix the casing the GeneAbout box.   The CSS transform goes to all titles, unfortunately and captializates every word.