### PR TITLE
Add props to control separator label display

### DIFF
--- a/src/RibbonBase/Block.js
+++ b/src/RibbonBase/Block.js
@@ -18,7 +18,7 @@ class Block extends React.Component {
   }
 
   render() {
-    const {slimitem, config} = this.props;
+    const {slimitem, config, showSeparatorLabel, showSeparatorLabelPrefix} = this.props;
 
     if (slimitem.separator === undefined) {
       let count = slimitem.uniqueAssocs.length;
@@ -62,15 +62,17 @@ class Block extends React.Component {
       return (
         <div className="ontology-ribbon__block">
           <div className="ontology-ribbon__tile-separator">
-            <div
-              className={'ontology-ribbon__strip-label'}
-              onClick={this.props.onClick}
-              onMouseEnter={this.props.onMouseEnter}
-              onMouseLeave={this.props.onMouseLeave}
-              style={{color: text_color}}
-            >
-              {prefix} {slimitem.class_label}
-            </div>
+            {showSeparatorLabel &&
+              <div
+                className={'ontology-ribbon__strip-label'}
+                onClick={this.props.onClick}
+                onMouseEnter={this.props.onMouseEnter}
+                onMouseLeave={this.props.onMouseLeave}
+                style={{color: text_color}}
+              >
+                {showSeparatorLabelPrefix && prefix} {slimitem.class_label}
+              </div>
+            }
           </div>
         </div>
 
@@ -86,11 +88,15 @@ Block.propTypes = {
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
   showTitle: PropTypes.bool,
+  showSeparatorLabel: PropTypes.bool,
+  showSeparatorLabelPrefix: PropTypes.bool,
   slimitem: PropTypes.object.isRequired,
 };
 
 Block.defaultProps = {
   showTitle: true,
+  showSeparatorLabel: true,
+  showSeparatorLabelPrefix: true,
 };
 
 export default Block;

--- a/src/RibbonBase/RibbonBase.js
+++ b/src/RibbonBase/RibbonBase.js
@@ -23,6 +23,8 @@ export default class RibbonBase extends React.Component {
               onClick={() => this.props.onSlimSelect(slimitem)}
               onMouseEnter={() => this.props.onSlimEnter(slimitem)}
               onMouseLeave={() => this.props.onSlimLeave(slimitem)}
+              showSeparatorLabel={this.props.showSeparatorLabels}
+              showSeparatorLabelPrefix={this.props.showSeparatorLabelPrefixes}
               showTitle={this.props.showBlockTitles}
               slimitem={slimitem}
             />
@@ -41,8 +43,12 @@ RibbonBase.propTypes = {
   onSlimLeave: PropTypes.func,
   onSlimSelect: PropTypes.func.isRequired,
   showBlockTitles: PropTypes.bool,
+  showSeparatorLabelPrefixes: PropTypes.bool,
+  showSeparatorLabels: PropTypes.bool,
 };
 
 RibbonBase.defaultProps = {
-  showBlockTitles: true
+  showBlockTitles: true,
+  showSeparatorLabelPrefixes: true,
+  showSeparatorLabels: true,
 };


### PR DESCRIPTION
For the alliance expression display, we need more fine-grained control over the separator labels. This change add properties to control how those labels are displayed. 