### PR TITLE
Correcting box-sizing on several elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@geneontology/ribbon",
-  "version": "1.4.12",
+  "version": "1.5.2-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.css
+++ b/src/index.css
@@ -29,6 +29,7 @@
   background-size: 700% 100%;
   display: inline-block;
   margin-right: 1rem !important;
+  box-sizing: content-box;
 }
 
 .ontology-ribbon-species-icon_agr.small {
@@ -107,6 +108,7 @@
   vertical-align: middle;
   text-shadow: -1px 0 silver, 0 1px silver, 1px 0 silver, 0 -1px silver;
   cursor: pointer;
+  box-sizing: content-box;
 }
 
 .ontology-ribbon__block:hover {
@@ -157,6 +159,7 @@
   padding-right: 15px;
   margin-right: 15px;
   border-radius: 5px;
+  box-sizing: content-box;
 }
 .ontology-ribbon__radio:hover {
   cursor: pointer;
@@ -466,6 +469,7 @@
   background-color:grey;
   display: inline-block;
   transition: all 0.2s;
+  box-sizing: content-box;
 }
 .checkbox:hover {
   box-shadow: 1px 1px 6px black;

--- a/src/view/GeneAbout.js
+++ b/src/view/GeneAbout.js
@@ -70,7 +70,7 @@ export default class GeneAbout extends React.Component {
                 >
                   {this.getLabel(title)}
                   {active_term ? active_term.toLowerCase() : ''}
-                  <FaExternalLink size={18} style={{paddingLeft: 10, textDecoration: 'none'}} />
+                  <FaExternalLink size={18} style={{paddingLeft: 10, textDecoration: 'none', boxSizing: 'content-box'}} />
                 </a>
               </span>
             }


### PR DESCRIPTION
Simple fix to give priority to Ribbon styling on its own elements by adding `box-sizing: content-box;` to several css classes, as well as directly add this property to a SVG representation in GeneAbout.js