### PR TITLE
Fixing safari color issue (rgb needs integer)

### DIFF
--- a/src/dataHelpers.js
+++ b/src/dataHelpers.js
@@ -381,10 +381,11 @@ export function heatColor(associations_count, hexColor, heatLevels) {
   // let fraction = Math.min(associations_count, heatLevels) / heatLevels;
 
   // this is the log version for interpolation (better highlight the most annotated classes)
+  // note: safari needs integer and not float for rgb function
   let fraction = Math.min(10 * Math.log(associations_count + 1), heatLevels) / heatLevels;
-  blockColor[0] = initColor[0] + fraction * (targetColor[0] - initColor[0]);
-  blockColor[1] = initColor[1] + fraction * (targetColor[1] - initColor[1]);
-  blockColor[2] = initColor[2] + fraction * (targetColor[2] - initColor[2]);
+  blockColor[0] = Math.round(initColor[0] + fraction * (targetColor[0] - initColor[0]));
+  blockColor[1] = Math.round(initColor[1] + fraction * (targetColor[1] - initColor[1]));
+  blockColor[2] = Math.round(initColor[2] + fraction * (targetColor[2] - initColor[2]));
 
   return 'rgb(' + blockColor[0] + ',' + blockColor[1] + ',' + blockColor[2] + ')';
 }


### PR DESCRIPTION
We lost ribbon colors on safari as the heatColor function was sending back rgb(float, float, float) and safari only accepts rgb(int, int, int):

<img width="1281" alt="screen shot 2019-02-06 at 11 25 50 am" src="https://user-images.githubusercontent.com/24249870/52368417-342acf00-2a03-11e9-8360-72491211d641.png">
