### PR TITLE
Ribbon label component + show/hide parameter

### DIFF
--- a/demo/src/Demo.js
+++ b/demo/src/Demo.js
@@ -30,6 +30,7 @@ function mapUrlToProps(url) {
   return {
     subject: url.subject,
     mode: url.mode,
+    entityLabel : url.entitylabel
   };
 }
 
@@ -45,11 +46,11 @@ class Demo extends React.Component {
   }
 
   render() {
-    const {subject, mode} = this.props;
+    const {subject, mode, entityLabel} = this.props;
 
     return (
       <div id='demo'>
-        <RibbonDataProvider mode={mode} subject={subject} >
+        <RibbonDataProvider mode={mode} subject={subject}>
           {
             ({entities, config, dataError, dataReceived}) => (
               <div>
@@ -59,6 +60,7 @@ class Demo extends React.Component {
                       entities={entities}
                       config={config}
                       showing={true}
+                      entityLabel={entityLabel}
                   /> :
                     null
                 }

--- a/src/Ribbon.js
+++ b/src/Ribbon.js
@@ -19,7 +19,8 @@ export default class Ribbon extends Component {
       currentblock: undefined,
       fetching: false,
       focalblock: undefined,
-      focalEntity: undefined
+      focalEntity: undefined,
+      entityLabel: this.props.entityLabel // left | right | none
     };
   }
 
@@ -131,6 +132,7 @@ export default class Ribbon extends Component {
               onSlimSelect={(entity, block) => this.handleSlimSelect(entity, block)}
               showBlockTitles={index === 0}
               key={entity.subject}
+              entityLabel={this.state.entityLabel}
           />
           })
         }
@@ -173,5 +175,9 @@ export default class Ribbon extends Component {
 Ribbon.propTypes = {
   entities : PropTypes.array.isRequired,
   config: PropTypes.object.isRequired,
-  showing: PropTypes.bool.isRequired,
+  showing: PropTypes.bool.isRequired
+};
+
+Ribbon.defaultProps = {
+  entityLabel: "right" // left | right | none
 };

--- a/src/RibbonBase/Block.js
+++ b/src/RibbonBase/Block.js
@@ -6,6 +6,7 @@ import variables from '../sass/_variables.scss';
 import {SlimType} from './../dataHelpers';
 
 class Block extends React.Component {
+  
   componentDidMount() {
     this.updateHeight();
   }

--- a/src/RibbonBase/RibbonBase.js
+++ b/src/RibbonBase/RibbonBase.js
@@ -3,11 +3,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SpeciesIcon from './../view/SpeciesIcon';
+import RibbonBaseLabel from './RibbonBaseLabel';
 import {getPrefixForId} from './../dataHelpers';
 
 import Block from './Block';
 
 export default class RibbonBase extends React.Component {
+
+
+  renderEntityLabel(location) {
+    if(this.props.entityLabel == "left" && location == "left"
+    || this.props.entityLabel == "right" && location == "right") {
+      return (
+        <RibbonBaseLabel title={this.props.title} entity={this.props.entity}/>
+      )
+    }
+    return(
+      <div></div>
+    )
+  }
 
   render() {
     let blocks = this.props.blocks;
@@ -15,7 +29,9 @@ export default class RibbonBase extends React.Component {
     let currentEntity = this.props.currentEntity;
 
     return (
-      <div className='ontology-ribbon__strip'> {
+      <div className='ontology-ribbon__strip'> 
+      {this.renderEntityLabel('left')}
+      {
         blocks.map((slimitem) => {
           let active = (currentblock !== undefined &&
                         slimitem.class_id === currentblock.class_id &&
@@ -37,10 +53,7 @@ export default class RibbonBase extends React.Component {
             />
           );
         }) }
-        <a href={"http://amigo.geneontology.org/amigo/gene_product/" + this.props.entity.subject.replace("MGI:","MGI:MGI:")} className="ontology-ribbon__label ribbon-link" target="blank">
-        <SpeciesIcon species={getPrefixForId(this.props.entity.subject)} />
-        {this.props.title}
-        </a>
+        {this.renderEntityLabel('right')}
       </div>
     );
   }
@@ -64,4 +77,5 @@ RibbonBase.defaultProps = {
   showBlockTitles: true,
   showSeparatorLabelPrefixes: true,
   showSeparatorLabels: true,
+  entityLabel: "right" // left | right | none
 };

--- a/src/RibbonBase/RibbonBase.js
+++ b/src/RibbonBase/RibbonBase.js
@@ -15,7 +15,7 @@ export default class RibbonBase extends React.Component {
     if(this.props.entityLabel == "left" && location == "left"
     || this.props.entityLabel == "right" && location == "right") {
       return (
-        <RibbonBaseLabel title={this.props.title} entity={this.props.entity}/>
+        <RibbonBaseLabel title={this.props.title} subject={this.props.entity.subject}/>
       )
     }
     return(

--- a/src/RibbonBase/RibbonBase.js
+++ b/src/RibbonBase/RibbonBase.js
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import SpeciesIcon from './../view/SpeciesIcon';
 import RibbonBaseLabel from './RibbonBaseLabel';
 import {getPrefixForId} from './../dataHelpers';
 

--- a/src/RibbonBase/RibbonBase.js
+++ b/src/RibbonBase/RibbonBase.js
@@ -15,7 +15,7 @@ export default class RibbonBase extends React.Component {
     if(this.props.entityLabel == "left" && location == "left"
     || this.props.entityLabel == "right" && location == "right") {
       return (
-        <RibbonBaseLabel title={this.props.title} subject={this.props.entity.subject}/>
+        <RibbonBaseLabel label={this.props.title} id={this.props.entity.subject}/>
       )
     }
     return(

--- a/src/RibbonBase/RibbonBaseLabel.js
+++ b/src/RibbonBase/RibbonBaseLabel.js
@@ -1,0 +1,26 @@
+'use strict';
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import SpeciesIcon from './../view/SpeciesIcon';
+import {getPrefixForId} from './../dataHelpers';
+
+import Block from './Block';
+
+export default class RibbonBaseLabel extends React.Component {
+
+  render() {
+    let blocks = this.props.blocks;
+    let currentblock = this.props.currentblock;
+    let currentEntity = this.props.currentEntity;
+
+    return (
+        <div className='ontology-ribbon__strip__label'>
+            <a href={"http://amigo.geneontology.org/amigo/gene_product/" + this.props.entity.subject.replace("MGI:","MGI:MGI:")} className="ontology-ribbon__label ribbon-link" target="blank">
+                <SpeciesIcon species={getPrefixForId(this.props.entity.subject)} />
+                {this.props.title}
+            </a>
+        </div>
+    )
+}
+}

--- a/src/RibbonBase/RibbonBaseLabel.js
+++ b/src/RibbonBase/RibbonBaseLabel.js
@@ -3,24 +3,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SpeciesIcon from './../view/SpeciesIcon';
-import {getPrefixForId} from './../dataHelpers';
+import { getPrefixForId } from './../dataHelpers';
 
 import Block from './Block';
 
 export default class RibbonBaseLabel extends React.Component {
 
-  render() {
-    let blocks = this.props.blocks;
-    let currentblock = this.props.currentblock;
-    let currentEntity = this.props.currentEntity;
-
-    return (
-        <div className='ontology-ribbon__strip__label'>
-            <a href={"http://amigo.geneontology.org/amigo/gene_product/" + this.props.entity.subject.replace("MGI:","MGI:MGI:")} className="ontology-ribbon__label ribbon-link" target="blank">
-                <SpeciesIcon species={getPrefixForId(this.props.entity.subject)} />
-                {this.props.title}
-            </a>
-        </div>
-    )
-}
+    render() {
+        return (
+            <div className='ontology-ribbon__strip__label'>
+                <a href={"http://amigo.geneontology.org/amigo/gene_product/" + this.props.subject.replace("MGI:", "MGI:MGI:")} className="ontology-ribbon__label ribbon-link" target="blank">
+                    <SpeciesIcon species={getPrefixForId(this.props.subject)} />
+                    {this.props.title}
+                </a>
+            </div>
+        )
+    }
 }

--- a/src/RibbonBase/RibbonBaseLabel.js
+++ b/src/RibbonBase/RibbonBaseLabel.js
@@ -12,9 +12,9 @@ export default class RibbonBaseLabel extends React.Component {
     render() {
         return (
             <div className='ontology-ribbon__strip__label'>
-                <a href={"http://amigo.geneontology.org/amigo/gene_product/" + this.props.subject.replace("MGI:", "MGI:MGI:")} className="ontology-ribbon__label ribbon-link" target="blank">
-                    <SpeciesIcon species={getPrefixForId(this.props.subject)} />
-                    {this.props.title}
+                <a href={"http://amigo.geneontology.org/amigo/gene_product/" + this.props.id.replace("MGI:", "MGI:MGI:")} className="ontology-ribbon__label ribbon-link" target="blank">
+                    <SpeciesIcon species={getPrefixForId(this.props.id)} />
+                    {this.props.label}
                 </a>
             </div>
         )

--- a/src/sass/_component-ribbon.scss
+++ b/src/sass/_component-ribbon.scss
@@ -8,7 +8,8 @@
     &__label {
         display: table-cell;
         vertical-align: bottom;
-        padding-left: 10px;                
+        padding: 0px 5px;
+        width: 90px;
     }
  
     &__header {
@@ -153,6 +154,10 @@
     &__strip {
         // margin-top: 15px;
         margin-top: 2px;
+
+        &__label {
+            display: contents;
+        }
     }
 
     &__strip-label {


### PR DESCRIPTION
… (left/right)

The following components have the additional parameter `entityLabel`:
* Demo
* Ribbon
* RibbonBase

It accepts 3 values: left | right | none, to either hide or show the label of an entity at the left or right location of the ribbon base. It is considered as a cell of the table.

In addition, the rendering of the entity label is now done by the separate RibbonBaseLabel that only needs id & label parameter (gene id & gene label).