### PR TITLE
Ability to count annotations and optional parameters to define what s…

### DIFF
--- a/src/Ribbon.js
+++ b/src/Ribbon.js
@@ -20,7 +20,9 @@ export default class Ribbon extends Component {
       fetching: false,
       focalblock: undefined,
       focalEntity: undefined,
-      entityLabel: this.props.entityLabel // left | right | none
+      entityLabel: this.props.entityLabel, // left | right | none
+      classLabels: this.props.classLabels,
+      annotationLabels: this.props.annotationLabels
     };
   }
 
@@ -133,6 +135,8 @@ export default class Ribbon extends Component {
               showBlockTitles={index === 0}
               key={entity.subject}
               entityLabel={this.state.entityLabel}
+              classLabels={this.state.classLabels}
+              annotationLabels={this.state.annotationLabels}
           />
           })
         }
@@ -179,5 +183,7 @@ Ribbon.propTypes = {
 };
 
 Ribbon.defaultProps = {
-  entityLabel: "right" // left | right | none
+  entityLabel: "right", // left | right | none
+  classLabels: ["class", "classes"],
+  annotationLabels: ["annotation", "annotations"]
 };

--- a/src/RibbonBase/Block.js
+++ b/src/RibbonBase/Block.js
@@ -27,8 +27,10 @@ class Block extends React.Component {
 
     if (slimitem.separator === undefined) {
       let count = slimitem.uniqueAssocs.length;
+      let countClasses = slimitem.uniqueAssocs ? slimitem.uniqueAssocs.length == 1 ? slimitem.uniqueAssocs.length + " " + this.props.classLabels[0] :  slimitem.uniqueAssocs.length + " " + this.props.classLabels[1] : "N/A"
+      let countAnnotations = slimitem.nbAnnotations ? slimitem.nbAnnotations == 1 ? slimitem.nbAnnotations + " " + this.props.annotationLabels[0] : slimitem.nbAnnotations + " " + this.props.annotationLabels[1] : "N/A"
       const tileHoverString = (count > 0) ?
-        count == 1 ? count + ' class ' : count + ' classes ' :
+        countClasses + ", " + countAnnotations :
         'No annotations to ' + slimitem.class_label;
 
       let blockTitleClass = `ontology-ribbon__block ${
@@ -112,6 +114,8 @@ Block.defaultProps = {
   showTitle: true,
   showSeparatorLabel: true,
   showSeparatorLabelPrefix: true,
+  classLabels : ["class", "classes"],
+  annotationLabels : ["annotation", "annotations"]
 };
 
 export default Block;

--- a/src/RibbonBase/RibbonBase.js
+++ b/src/RibbonBase/RibbonBase.js
@@ -9,7 +9,6 @@ import Block from './Block';
 
 export default class RibbonBase extends React.Component {
 
-
   renderEntityLabel(location) {
     if(this.props.entityLabel == "left" && location == "left"
     || this.props.entityLabel == "right" && location == "right") {
@@ -49,6 +48,8 @@ export default class RibbonBase extends React.Component {
               showSeparatorLabelPrefix={this.props.showSeparatorLabelPrefixes}
               showTitle={this.props.showBlockTitles}
               slimitem={slimitem}
+              classLabels={this.props.classLabels}
+              annotationLabels={this.props.annotationLabels}
             />
           );
         }) }
@@ -76,5 +77,7 @@ RibbonBase.defaultProps = {
   showBlockTitles: true,
   showSeparatorLabelPrefixes: true,
   showSeparatorLabels: true,
-  entityLabel: "right" // left | right | none
+  entityLabel: "right", // left | right | none,
+  classLabels: ["class", "classes"],
+  annotationLabels: ["annotation", "annotations"]
 };

--- a/src/dataHelpers.js
+++ b/src/dataHelpers.js
@@ -153,6 +153,7 @@ export function createSlims(subject, config, associations, termAspect) {
     // set up uniques and color too
     slimitem.uniqueIDs = [];
     slimitem.uniqueAssocs = [];
+    slimitem.nbAnnotations = 0;
     slimitem.color = '#fff';
 
     other = slimitem.class_label.toLowerCase().includes('other');
@@ -255,7 +256,9 @@ export function createSlims(subject, config, associations, termAspect) {
 
     if (slimitem.uniqueAssocs.length > 0) {
       slimitem.uniqueAssocs.sort(sortAssociations);
+      slimitem.nbAnnotations = countAnnotations(slimitem);
       slimitem.color = heatColor(slimitem.uniqueAssocs.length, config.annot_color, config.heatLevels);
+      slimitem.colorNbAnnotations = heatColor(slimitem.nbAnnotations, config.annot_color, config.heatLevels);
     }
     return slimitem;
   });
@@ -305,6 +308,7 @@ function gatherAllAnnotations(aspectItem, blocks, config) {
   let slimitem = {};
   slimitem.uniqueIDs = [];
   slimitem.uniqueAssocs = [];
+  slimitem.nbAnnotations = 0;
   slimitem.color = '#fff';
   slimitem.class_label = "All " + aspectItem.class_label.toLowerCase();
   slimitem.class_id = aspectItem.aspect + " all";
@@ -329,10 +333,22 @@ function gatherAllAnnotations(aspectItem, blocks, config) {
 
   if (slimitem.uniqueAssocs.length > 0) {
     slimitem.uniqueAssocs.sort(sortAssociations);
+    slimitem.nbAnnotations = countAnnotations(slimitem);
     slimitem.color = heatColor(slimitem.uniqueAssocs.length, config.annot_color, config.heatLevels);
+    slimitem.colorNbAnnotations = heatColor(slimitem.nbAnnotations, config.annot_color, config.heatLevels);
   }
 
   return slimitem;
+}
+
+function countAnnotations(slimitem) {
+  let count = 0;
+  slimitem.uniqueAssocs.forEach(elt => {
+    elt.evidence_map.forEach((v, k) => {
+		count += v.length;
+    })
+  })  
+  return count;
 }
 
 


### PR DESCRIPTION
…hould be shown instead of "class" or "annotation"

To enable this functionality, the `slimitem` object should have a nbAnnotations property.

It is possible to change the label of "class" and "annotation" shown in the popup by changing either in Ribbon, RibbonBase or Block (depending of use case) the value of parameters `classLabels`and `annotationLabels`. Those parameters accept an array of 2 items to enable both the singular and plural form of the word to be shown