### PR TITLE
Allow overriding subject labels

### DIFF
--- a/src/components/GenericRibbon.js
+++ b/src/components/GenericRibbon.js
@@ -42,7 +42,7 @@ class GenericRibbon extends Component {
             itemEnter : props.itemEnter,
             itemLeave : props.itemLeave,
             itemOver : props.itemOver,
-            itemClick : props.itemClick    
+            itemClick : props.itemClick
         }
     }
 
@@ -88,7 +88,7 @@ class GenericRibbon extends Component {
             itemEnter : nextProps.itemEnter,
             itemLeave : nextProps.itemLeave,
             itemOver : nextProps.itemOver,
-            itemClick : nextProps.itemClick    
+            itemClick : nextProps.itemClick
         });
         // console.log("GR::componentWillReceiveProps: (state)" , this.state);
     }
@@ -108,36 +108,37 @@ class GenericRibbon extends Component {
 
     renderRibbon() {
         return (
-            <div className='ontology-ribbon' style={{ display: 'block' }}>
+            <div className='ontology-ribbon' style={{ display: 'table' }}>
                 <GenericRibbonHeader    categories={this.state.categories}
                                         addSubjectLabelWidth={(!this.state.hideFirstSubjectLabel) || (this.state.hideFirstSubjectLabel && this.state.subjects.length > 1)}
-                                        subjectLabelPosition={this.state.subjectLabelPosition} 
+                                        subjectLabelPosition={this.state.subjectLabelPosition}
                                         showItemAll={this.state.showItemAll}
                                         />
-                <GenericRibbonSubjects  categories={this.state.categories} 
-                                        subjects={this.state.subjects} 
+                <GenericRibbonSubjects  categories={this.state.categories}
+                                        subjects={this.state.subjects}
 
                                         selected={this.state.selected}
                                         showItemAll={this.state.showItemAll}
                                         classLabels={this.state.classLabels}
                                         annotationLabels={this.state.annotationLabels}
 
-                                        colorBy={this.state.colorBy} 
-                                        binaryColor={this.state.binaryColor} 
+                                        colorBy={this.state.colorBy}
+                                        binaryColor={this.state.binaryColor}
                                         minColor={this.state.minColor}
                                         maxColor={this.state.maxColor}
-                                        maxHeatLevel={this.state.maxHeatLevel} 
+                                        maxHeatLevel={this.state.maxHeatLevel}
 
                                         hideFirstSubjectLabel={this.state.hideFirstSubjectLabel}
                                         newTab={this.state.newTab}
                                         subjectUseTaxonIcon={this.state.subjectUseTaxonIcon}
+                                        subjectLabel={this.props.subjectLabel}
                                         subjectLabelPosition={this.state.subjectLabelPosition}
                                         subjectBaseURL={this.state.subjectBaseURL}
-                                        
+
                                         itemEnter={this.state.itemEnter}
                                         itemLeave={this.state.itemLeave}
                                         itemOver={this.state.itemOver}
-                                        itemClick={this.state.itemClick} 
+                                        itemClick={this.state.itemClick}
                                         />
             </div>
         )
@@ -155,6 +156,7 @@ GenericRibbon.propTypes = {
     hideFirstSubjectLabel : PropTypes.bool,
     newTab : PropTypes.bool,
     subjectUseTaxonIcon : PropTypes.bool,
+    subjectLabel : PropTypes.func,
     subjectLabelPosition: PropTypes.number,
     subjectBaseURL : PropTypes.string,
 
@@ -170,11 +172,11 @@ GenericRibbon.propTypes = {
     subjectLeave : PropTypes.func,
     subjectOver : PropTypes.func,
     subjectClick : PropTypes.func,
-    
+
     itemEnter : PropTypes.func,
     itemLeave : PropTypes.func,
     itemOver : PropTypes.func,
-    itemClick : PropTypes.func 
+    itemClick : PropTypes.func
 }
 
 GenericRibbon.defaultProps = {

--- a/src/components/GenericRibbonHeader.js
+++ b/src/components/GenericRibbonHeader.js
@@ -58,13 +58,10 @@ class GenericRibbonHeader extends Component {
         }       */}
 
         { (this.state.subjectLabelPosition == POSITION.LEFT && this.state.addSubjectLabelWidth) ?
-          <div style={{ display : 'inline-block',
-                        width: '180px',
-                        padding: '0px 1px'
-                      }} />
+          <div className='ontology-ribbon__item__subject' />
                                       : ''
-        }      
-      
+        }
+
         { (this.state.showItemAll) ?
             <GenericRibbonHeaderCategory category={ { groups : [ { id: "all", type: "All", label: "All annotations" } ] } } />
             : ''

--- a/src/components/GenericRibbonSubject.js
+++ b/src/components/GenericRibbonSubject.js
@@ -36,7 +36,7 @@ class GenericRibbonSubject extends Component {
       itemEnter : props.itemEnter,
       itemLeave : props.itemLeave,
       itemOver : props.itemOver,
-      itemClick : props.itemClick    
+      itemClick : props.itemClick
     }
   }
 
@@ -76,7 +76,7 @@ class GenericRibbonSubject extends Component {
       itemEnter : nextProps.itemEnter,
       itemLeave : nextProps.itemLeave,
       itemOver : nextProps.itemOver,
-      itemClick : nextProps.itemClick    
+      itemClick : nextProps.itemClick
     });
   }
 
@@ -87,28 +87,30 @@ class GenericRibbonSubject extends Component {
     return (
       <div className='ontology-ribbon__strip'>
 
-        { (this.state.subjectLabelPosition == POSITION.LEFT && !this.state.hideLabel) ?
-          <GenericRibbonSubjectLabel  subjectId={this.state.subject.id} 
-                                      subjectLabel={this.state.subject.label}
-                                      subjectTaxon={this.state.subject.taxon_label}
-                                      subjectBaseURL={this.state.subjectBaseURL} 
-                                      useTaxonIcon={this.state.useTaxonIcon}
-                                      newTab={this.state.newTab}
-                                      />
-                                      : ''
-        }      
+        { (this.state.subjectLabelPosition == POSITION.LEFT && !this.state.hideLabel) &&
+          (this.props.subjectLabel ?
+            <div className='ontology-ribbon__item__subject'>{this.props.subjectLabel(this.state.subject)}</div> :
+            <GenericRibbonSubjectLabel subjectId={this.state.subject.id}
+                                       subjectLabel={this.state.subject.label}
+                                       subjectTaxon={this.state.subject.taxon_label}
+                                       subjectBaseURL={this.state.subjectBaseURL}
+                                       useTaxonIcon={this.state.useTaxonIcon}
+                                       newTab={this.state.newTab}
+            />
+          )
+        }
 
         { (this.state.showItemAll) ?
-          <div  className='ontology-ribbon__item__category'>        
+          <div  className='ontology-ribbon__item__category'>
           <GenericRibbonItem          subject={this.state.subject}
-                                      group={ 
+                                      group={
                                         {
                                           "id" : "all",
                                           "label" : "All annotations",
                                           "description" : "Contains all the annotations for all groups",
                                           "type" : "GlobalAll"
                                         }
-                                      } 
+                                      }
                                       data={
                                         {
                                           "ALL": {
@@ -116,11 +118,11 @@ class GenericRibbonSubject extends Component {
                                             "nb_annotations": this.state.subject.nb_annotations
                                           }
                                         }
-                                      } 
+                                      }
 
                                       isSelected={
-                                        (this.state.selected && this.state.selected.subject && this.state.selected.group) 
-                                            ? this.state.selected.subject.id == this.state.subject.id 
+                                        (this.state.selected && this.state.selected.subject && this.state.selected.group)
+                                            ? this.state.selected.subject.id == this.state.subject.id
                                               && this.state.selected.group.id == "all"
                                             : false
                                       }
@@ -128,24 +130,24 @@ class GenericRibbonSubject extends Component {
 
                                       classLabels={this.state.classLabels}
                                       annotationLabels={this.state.annotationLabels}
-                                      colorBy={this.state.colorBy} 
-                                      binaryColor={this.state.binaryColor} 
+                                      colorBy={this.state.colorBy}
+                                      binaryColor={this.state.binaryColor}
                                       minColor={this.state.minColor}
                                       maxColor={this.state.maxColor}
-                                      maxHeatLevel={this.state.maxHeatLevel}    
-                          
+                                      maxHeatLevel={this.state.maxHeatLevel}
+
                                       itemEnter={this.state.itemEnter}
                                       itemLeave={this.state.itemLeave}
                                       itemOver={this.state.itemOver}
                                       itemClick={this.state.itemClick}
-                                                                  
-                                      />                        
+
+                                      />
                                       </div>
                                       : ''
         }
 
         {
-          this.state.categories.map((category, index) => {   
+          this.state.categories.map((category) => {
             return (
               <div  className='ontology-ribbon__item__category'
                     key={this.state.subject + "_" + category.id}>
@@ -153,30 +155,30 @@ class GenericRibbonSubject extends Component {
                 category.groups.map((group, index) => {
                   return (
                     <GenericRibbonItem  subject={this.state.subject}
-                                        group={group} 
+                                        group={group}
                                         data={this.state.subject.groups[group.id]}
 
                                         isSelected={
-                                          (this.state.selected && this.state.selected.subject && this.state.selected.group) 
-                                              ? this.state.selected.subject.id == this.state.subject.id 
-                                                && this.state.selected.group.id == group.id 
-                                                && this.state.selected.group.type == group.type 
+                                          (this.state.selected && this.state.selected.subject && this.state.selected.group)
+                                              ? this.state.selected.subject.id == this.state.subject.id
+                                                && this.state.selected.group.id == group.id
+                                                && this.state.selected.group.type == group.type
                                               : false
                                         }
-  
+
                                         classLabels={this.state.classLabels}
                                         annotationLabels={this.state.annotationLabels}
-                                        colorBy={this.state.colorBy} 
-                                        binaryColor={this.state.binaryColor} 
+                                        colorBy={this.state.colorBy}
+                                        binaryColor={this.state.binaryColor}
                                         minColor={this.state.minColor}
                                         maxColor={this.state.maxColor}
-                                        maxHeatLevel={this.state.maxHeatLevel}    
-                            
+                                        maxHeatLevel={this.state.maxHeatLevel}
+
                                         itemEnter={this.state.itemEnter}
                                         itemLeave={this.state.itemLeave}
                                         itemOver={this.state.itemOver}
                                         itemClick={this.state.itemClick}
-                                                                    
+
                                         key={this.state.subject + "_" + category.id + "_" + group.id + "_" + index} />
                   )
                 })
@@ -187,15 +189,15 @@ class GenericRibbonSubject extends Component {
           })
 
         }
-        
+
         { (this.state.subjectLabelPosition == POSITION.RIGHT && !this.state.hideLabel) ?
-          <GenericRibbonSubjectLabel  subjectId={this.state.subject.id} 
+          <GenericRibbonSubjectLabel  subjectId={this.state.subject.id}
                                       subjectLabel={this.state.subject.label}
                                       subjectTaxon={this.state.subject.taxon_label}
                                       subjectBaseURL={this.state.subjectBaseURL}
                                       useTaxonIcon={this.state.useTaxonIcon}
                                       newTab={this.state.newTab}
-                                      />                                      
+                                      />
                                       : ''
         }
       </div>
@@ -215,6 +217,7 @@ GenericRibbonSubject.propTypes = {
   hideLabel: PropTypes.bool,
   newTab : PropTypes.bool,
   useTaxonIcon : PropTypes.bool,
+  subjectLabel : PropTypes.func,
   subjectLabelPosition: PropTypes.number,
   subjectBaseURL : PropTypes.string,
 
@@ -229,7 +232,7 @@ GenericRibbonSubject.propTypes = {
   itemEnter : PropTypes.func,
   itemLeave : PropTypes.func,
   itemOver : PropTypes.func,
-  itemClick : PropTypes.func  
+  itemClick : PropTypes.func
 }
 
 GenericRibbonSubject.defaultProps = {

--- a/src/components/GenericRibbonSubject.js
+++ b/src/components/GenericRibbonSubject.js
@@ -190,15 +190,17 @@ class GenericRibbonSubject extends Component {
 
         }
 
-        { (this.state.subjectLabelPosition == POSITION.RIGHT && !this.state.hideLabel) ?
-          <GenericRibbonSubjectLabel  subjectId={this.state.subject.id}
-                                      subjectLabel={this.state.subject.label}
-                                      subjectTaxon={this.state.subject.taxon_label}
-                                      subjectBaseURL={this.state.subjectBaseURL}
-                                      useTaxonIcon={this.state.useTaxonIcon}
-                                      newTab={this.state.newTab}
-                                      />
-                                      : ''
+        { (this.state.subjectLabelPosition == POSITION.RIGHT && !this.state.hideLabel) &&
+          (this.props.subjectLabel ?
+            <div className='ontology-ribbon__item__subject'>{this.props.subjectLabel(this.state.subject)}</div> :
+            <GenericRibbonSubjectLabel  subjectId={this.state.subject.id}
+                                        subjectLabel={this.state.subject.label}
+                                        subjectTaxon={this.state.subject.taxon_label}
+                                        subjectBaseURL={this.state.subjectBaseURL}
+                                        useTaxonIcon={this.state.useTaxonIcon}
+                                        newTab={this.state.newTab}
+                                        />
+          )
         }
       </div>
     )

--- a/src/components/GenericRibbonSubjects.js
+++ b/src/components/GenericRibbonSubjects.js
@@ -40,7 +40,7 @@ class GenericRibbonSubjects extends Component {
             itemEnter : props.itemEnter,
             itemLeave : props.itemLeave,
             itemOver : props.itemOver,
-            itemClick : props.itemClick    
+            itemClick : props.itemClick
         }
     }
 
@@ -59,7 +59,7 @@ class GenericRibbonSubjects extends Component {
         this.setState({
             categories : nextProps.categories,
             subjects: nextProps.subjects,
-            
+
             selected : nextProps.selected,
 
             showItemAll : nextProps.showItemAll,
@@ -87,51 +87,45 @@ class GenericRibbonSubjects extends Component {
             itemEnter : nextProps.itemEnter,
             itemLeave : nextProps.itemLeave,
             itemOver : nextProps.itemOver,
-            itemClick : nextProps.itemClick     
+            itemClick : nextProps.itemClick
         });
         // console.log("GRSS::componentWillReceiveProps: (state)" , this.state);
     }
 
     render() {
         // console.log("GRSS::render (state): ", this.state);
-        return (
-            <div className='ontology-ribbon__subjects'>
-                {
-                    this.state.subjects.map((subject, index) => {
+        return this.state.subjects.map((subject) => {
                         return (
-                            <GenericRibbonSubject   categories={this.state.categories} 
-                                                    subject={subject} 
+                            <GenericRibbonSubject   categories={this.state.categories}
+                                                    subject={subject}
 
                                                     selected={this.state.selected}
 
                                                     showItemAll={this.state.showItemAll}
                                                     classLabels={this.state.classLabels}
                                                     annotationLabels={this.state.annotationLabels}
-            
-                                                    colorBy={this.state.colorBy} 
-                                                    binaryColor={this.state.binaryColor} 
+
+                                                    colorBy={this.state.colorBy}
+                                                    binaryColor={this.state.binaryColor}
                                                     minColor={this.state.minColor}
                                                     maxColor={this.state.maxColor}
-                                                    maxHeatLevel={this.state.maxHeatLevel}    
+                                                    maxHeatLevel={this.state.maxHeatLevel}
 
                                                     hideLabel={this.state.hideFirstSubjectLabel && this.state.subjects.length == 1}
                                                     newTab={this.state.newTab}
                                                     useTaxonIcon={this.state.subjectUseTaxonIcon}
+                                                    subjectLabel={this.props.subjectLabel}
                                                     subjectLabelPosition={this.state.subjectLabelPosition}
                                                     subjectBaseURL={this.state.subjectBaseURL}
-                                                    
+
                                                     itemEnter={this.state.itemEnter}
                                                     itemLeave={this.state.itemLeave}
                                                     itemOver={this.state.itemOver}
                                                     itemClick={this.state.itemClick}
 
-                                                    key={"subject_" + index} />
+                                                    key={"subject_" + subject.id} />
                         )
-                    })
-                }
-            </div>
-        )
-
+                    });
     }
 
 }
@@ -147,6 +141,7 @@ GenericRibbonSubjects.propTypes = {
     hideFirstSubjectLabel : PropTypes.bool,
     newTab : PropTypes.bool,
     subjectUseTaxonIcon : PropTypes.bool,
+    subjectLabel : PropTypes.func,
     subjectLabelPosition: PropTypes.number,
     subjectBaseURL : PropTypes.string,
 
@@ -162,11 +157,11 @@ GenericRibbonSubjects.propTypes = {
     subjectLeave : PropTypes.func,
     subjectOver : PropTypes.func,
     subjectClick : PropTypes.func,
-    
+
     itemEnter : PropTypes.func,
     itemLeave : PropTypes.func,
     itemOver : PropTypes.func,
-    itemClick : PropTypes.func    
+    itemClick : PropTypes.func
 }
 
 GenericRibbonSubjects.defaultProps = {

--- a/src/sass/_component-ribbon.scss
+++ b/src/sass/_component-ribbon.scss
@@ -9,7 +9,6 @@
         display: table-cell;
         vertical-align: bottom;
         padding: 0px 5px;
-        width: 180px;
     }
 
     &__header {
@@ -21,8 +20,8 @@
         border-radius: $ribbon-table-header-border-radius;
 
         &--border-bottom {
-            border-bottom: 2.5px solid rgba(128, 128, 128, 0.2);                
-        }    
+            border-bottom: 2.5px solid rgba(128, 128, 128, 0.2);
+        }
     }
 
     &__headline {
@@ -33,8 +32,8 @@
         width: 100%;
 
         &--border-bottom {
-            border-bottom: 2.5px solid rgba(128, 128, 128, 0.2);                
-        }    
+            border-bottom: 2.5px solid rgba(128, 128, 128, 0.2);
+        }
     }
 
     &__term-column {
@@ -169,6 +168,7 @@
 
     &__strip {
         // margin-top: 15px;
+        display: table-row;
         margin-top: 2px;
 
         &__label {
@@ -209,7 +209,7 @@
             display: table-cell;
             vertical-align: bottom;
             height: 200px;
-        }            
+        }
     }
 
     &__item {
@@ -224,7 +224,7 @@
         }
 
         &__subject {
-            display: inline-block;
+            display: table-cell;
         }
     }
 
@@ -305,7 +305,7 @@
                     cursor: pointer;
                 }
             }
-    
+
 
             &--disabled {
                 cursor: not-allowed !important;
@@ -316,7 +316,7 @@
                 cursor: not-allowed !important;
                 transform: none !important;
             }
-        
+
             &__separator {
                 position: relative;
                 margin-right: -1px;
@@ -455,7 +455,7 @@
             }
 
             &--border-bottom:not(:last-child) {
-                border-bottom: 1.5px solid rgba(128, 128, 128, 0.2);                
+                border-bottom: 1.5px solid rgba(128, 128, 128, 0.2);
             }
 
             &--focus {


### PR DESCRIPTION
Apologies for the messy diff. I guess my editor automatically removed trailing whitespace. 

The main change is in `GenericRibbonSubject` where it now accepts a function prop (`subjectLabel`) which can be used to place a custom label component, overriding the default. 

The changes to styles and css classes are to remove the hardcoded 180px width of the label column and instead allow it to be sized based on the actual contents. 